### PR TITLE
remove abs.yaml

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  jcmorin-ana-org: dpcpp-2023.1.0


### PR DESCRIPTION
Changes;
- remove abs.yaml
- no increase of build number, as the previous PR was not uploaded